### PR TITLE
fix(index.d.ts): make `port` option optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ declare module 'http2-proxy' {
   interface http2Options extends Tls.ConnectionOptions {
     timeout?: number;
     hostname: string;
-    port: number;
+    port?: number;
     protocol?: 'https';
     path?: string;
     proxyTimeout?: number;
@@ -77,7 +77,7 @@ declare module 'http2-proxy' {
   interface http1Options extends Net.ConnectOpts {
     timeout?: number;
     hostname: string;
-    port: number;
+    port?: number;
     protocol?: 'http' | 'https';
     path?: string;
     proxyTimeout?: number;


### PR DESCRIPTION
In HTTP request, if the port is default (http -> 80, https -> 443), the port of url can be optional. 

And in the [source code](https://github.com/nxtedition/node-http2-proxy/blob/master/compat.js#L82), it also handles scenarios where port is undefined (or not defined).

So I think in this scene the config of port shouldn't be written, and I omit the port property in my own project and it works fine (with the TypeScript error of course).

I changed the definition of package and make it optional.