### PR TITLE
fix: add `request.write(data)` for POST/PUT/DELETE request

### DIFF
--- a/compat.js
+++ b/compat.js
@@ -129,6 +129,7 @@ module.exports = function (proxy) {
             throw new Error('invalid protocol')
           }
           ret = agent.request(ureq)
+          ret.write(JSON.stringify(req.body));
         }
 
         return ret


### PR DESCRIPTION
In my project, I found that the request always hang up and timeout when I proxy POST requests. But GET method is successful. 

Finally I check the compat function and find the `request.write()` is not be called when I proxy a POST request.
> reference：https://nodejs.org/dist/latest-v18.x/docs/api/http.html#requestwritechunk-encoding-callback  


The request should be like that:
```js
const http = require('http');

const body = {
   "data": {
     "channel" : "aaa",
     "appkey" : "bbb"
  },
  "sign" : "22334455",
  "token" : "bb667788"
};

const bodyString = JSON.stringify(body);

const headers = {
  'Content-Type': 'application/json',
  'Content-Length': bodyString.length
};

const options = {
  host: '127.0.0.1',
  port: 3005,
  path: '/Config',
  method: 'POST',
  headers: headers
};

const req = http.request(options, function(res) {
    ...
})

req.write(bodyString);
req.end();
```